### PR TITLE
LayerNormLSTM fix and some other improvements

### DIFF
--- a/lstms/__init__.py
+++ b/lstms/__init__.py
@@ -1,5 +1,31 @@
 #!/usr/bin/env python
 
-from .lstm import *
-from .normalize import *
-from .container import *
+from .container import MultiLayerLSTM
+from .lstm import (
+    LSTM,
+    GalLSTM,
+    LayerNormGalLSTM,
+    LayerNormLSTM,
+    LayerNormMoonLSTM,
+    LayerNormSemeniutaLSTM,
+    MoonLSTM,
+    SemeniutaLSTM,
+    SlowLSTM,
+)
+from .normalize import BaLayerNorm, BradburyLayerNorm, LayerNorm
+
+__all__ = [
+    "GalLSTM",
+    "LayerNormGalLSTM",
+    "LayerNormLSTM",
+    "LayerNormMoonLSTM",
+    "LayerNormSemeniutaLSTM",
+    "MoonLSTM",
+    "SlowLSTM",
+    "LSTM",
+    "SemeniutaLSTM",
+    "MultiLayerLSTM",
+    "BaLayerNorm",
+    "BradburyLayerNorm",
+    "LayerNorm",
+]

--- a/lstms/container.py
+++ b/lstms/container.py
@@ -1,23 +1,19 @@
 #!/usr/bin/env python
-
-import math
-import torch as th
-import torch.nn as nn
-import torch.nn.functional as F
-from torch import Tensor as T
-from torch.nn import Parameter as P
-from torch.autograd import Variable as V
-
 """
 A helper class to contruct multi-layered LSTMs.
 """
+import math
+
+import torch as th
+import torch.nn as nn
+from torch.autograd import Variable
 
 
 class MultiLayerLSTM(nn.Module):
 
     """
     MultiLayer LSTM of any type.
-    
+
     Note: Dropout is deactivated on the last layer.
     """
 
@@ -30,10 +26,9 @@ class MultiLayerLSTM(nn.Module):
             layer = rnn(input_size=prev_size, hidden_size=size, *args, **kwargs)
             layers.append(layer)
             prev_size = size
-        if 'dropout' in kwargs:
-            del kwargs['dropout']
-        layer = rnn(input_size=prev_size, hidden_size=layer_sizes[-1], dropout=0.0,
-                    *args, **kwargs)
+        if "dropout" in kwargs:
+            del kwargs["dropout"]
+        layer = rnn(input_size=prev_size, hidden_size=layer_sizes[-1], dropout=0.0, *args, **kwargs)
         layers.append(layer)
         self.layers = layers
         self.layer_sizes = layer_sizes
@@ -41,27 +36,29 @@ class MultiLayerLSTM(nn.Module):
         self.params = nn.ModuleList(layers)
 
     def reset_parameters(self):
-        for l in self.layers:
-            l.reset_parameters()
+        for layer in self.layers:
+            layer.reset_parameters()
 
-    def create_hiddens(self, bsz=1):
+    def create_hiddens(self, batch_size=1):
         # Uses Xavier init here.
         hiddens = []
-        for l in self.layers:
-            std = math.sqrt(2.0 / (l.input_size + l.hidden_size))
-            hiddens.append([V(T(1, bsz, l.hidden_size).normal_(0, std)),
-                            V(T(1, bsz, l.hidden_size).normal_(0, std))])
+        for layer in self.layers:
+            std = math.sqrt(2.0 / (layer.input_size + layer.hidden_size))
+            hiddens.append(
+                [
+                    Variable(th.empty(1, batch_size, layer.hidden_size).normal_(0, std)),
+                    Variable(th.empty(1, batch_size, layer.hidden_size).normal_(0, std)),
+                ]
+            )
         return hiddens
 
     def sample_mask(self):
-        for l in self.layers:
-            l.sample_mask()
+        for layer in self.layers:
+            layer.sample_mask()
 
     def forward(self, x, hiddens):
         new_hiddens = []
-        for l, h in zip(self.layers, hiddens):
-            print('asdf')
-            x, new_h = l(x, h)
+        for layer, h in zip(self.layers, hiddens):
+            x, new_h = layer(x, h)
             new_hiddens.append(new_h)
         return x, new_hiddens
-

--- a/lstms/container.py
+++ b/lstms/container.py
@@ -3,10 +3,12 @@
 A helper class to contruct multi-layered LSTMs.
 """
 import math
+from typing import List, Tuple, Type
 
 import torch as th
 import torch.nn as nn
-from torch.autograd import Variable
+
+from .lstm import LSTM
 
 
 class MultiLayerLSTM(nn.Module):
@@ -17,38 +19,38 @@ class MultiLayerLSTM(nn.Module):
     Note: Dropout is deactivated on the last layer.
     """
 
-    def __init__(self, input_size, layer_type, layer_sizes=(64, 64), *args, **kwargs):
+    def __init__(self, input_size: int, layer_type: Type[LSTM], layer_sizes: List[int] = (64, 64), *args, **kwargs):
         super(MultiLayerLSTM, self).__init__()
         rnn = layer_type
-        layers = []
+        self.layers: List[LSTM] = []
         prev_size = input_size
         for size in layer_sizes[:-1]:
             layer = rnn(input_size=prev_size, hidden_size=size, *args, **kwargs)
-            layers.append(layer)
+            self.layers.append(layer)
             prev_size = size
         if "dropout" in kwargs:
             del kwargs["dropout"]
-        layer = rnn(input_size=prev_size, hidden_size=layer_sizes[-1], dropout=0.0, *args, **kwargs)
-        layers.append(layer)
-        self.layers = layers
+        if len(layer_sizes) > 0:
+            layer = rnn(input_size=prev_size, hidden_size=layer_sizes[-1], dropout=0.0, *args, **kwargs)
+            self.layers.append(layer)
         self.layer_sizes = layer_sizes
         self.input_size = input_size
-        self.params = nn.ModuleList(layers)
+        self.params = nn.ModuleList(self.layers)
 
     def reset_parameters(self):
         for layer in self.layers:
             layer.reset_parameters()
 
-    def create_hiddens(self, batch_size=1):
+    def create_hiddens(self, batch_size: int = 1) -> List[Tuple[th.Tensor, th.Tensor]]:
         # Uses Xavier init here.
-        hiddens = []
+        hiddens: List[Tuple[th.Tensor, th.Tensor]] = []
         for layer in self.layers:
             std = math.sqrt(2.0 / (layer.input_size + layer.hidden_size))
             hiddens.append(
-                [
-                    Variable(th.empty(1, batch_size, layer.hidden_size).normal_(0, std)),
-                    Variable(th.empty(1, batch_size, layer.hidden_size).normal_(0, std)),
-                ]
+                (
+                    th.empty(1, batch_size, layer.hidden_size).normal_(0, std),
+                    th.empty(1, batch_size, layer.hidden_size).normal_(0, std),
+                )
             )
         return hiddens
 
@@ -56,8 +58,10 @@ class MultiLayerLSTM(nn.Module):
         for layer in self.layers:
             layer.sample_mask()
 
-    def forward(self, x, hiddens):
-        new_hiddens = []
+    def forward(
+        self, x: th.Tensor, hiddens: Tuple[th.Tensor, th.Tensor]
+    ) -> Tuple[th.Tensor, List[Tuple[th.Tensor, th.Tensor]]]:
+        new_hiddens: List[Tuple[th.Tensor, th.Tensor]] = []
         for layer, h in zip(self.layers, hiddens):
             x, new_h = layer(x, h)
             new_hiddens.append(new_h)

--- a/lstms/lstm.py
+++ b/lstms/lstm.py
@@ -283,7 +283,7 @@ class LayerNormLSTM(LSTM):
         return h_t, (h_t, c_t)
 
 
-class LayerNormGalLSTM(LSTM):
+class LayerNormGalLSTM(LayerNormLSTM):
 
     """
     Mixes GalLSTM's Dropout with Layer Normalization
@@ -295,7 +295,7 @@ class LayerNormGalLSTM(LSTM):
         self.sample_mask()
 
 
-class LayerNormMoonLSTM(LSTM):
+class LayerNormMoonLSTM(LayerNormLSTM):
 
     """
     Mixes MoonLSTM's Dropout with Layer Normalization
@@ -307,7 +307,7 @@ class LayerNormMoonLSTM(LSTM):
         self.sample_mask()
 
 
-class LayerNormSemeniutaLSTM(LSTM):
+class LayerNormSemeniutaLSTM(LayerNormLSTM):
 
     """
     Mixes SemeniutaLSTM's Dropout with Layer Normalization

--- a/lstms/normalize.py
+++ b/lstms/normalize.py
@@ -42,7 +42,7 @@ class LayerNorm(nn.Module):
     def forward(self, x):
         size = x.size()
         x = x.view(x.size(0), -1)
-        x = (x - th.mean(x, 1).expand_as(x)) / th.sqrt(th.var(x, 1).expand_as(x) + self.epsilon)
+        x = (x - th.mean(x, 1).unsqueeze(1)) / th.sqrt(th.var(x, 1).unsqueeze(1) + self.epsilon)
         if self.learnable:
             x = self.alpha.expand_as(x) * x + self.beta.expand_as(x)
         return x.view(size)
@@ -96,9 +96,9 @@ class BaLayerNorm(nn.Module):
     def forward(self, x):
         size = x.size()
         x = x.view(x.size(0), -1)
-        mean = th.mean(x, 1).expand_as(x)
+        mean = th.mean(x, 1).unsqueeze(1)
         center = x - mean
-        std = th.sqrt(th.mean(th.square(center), 1)).expand_as(x)
+        std = th.sqrt(th.mean(th.square(center), 1)).unsqueeze(1)
         output = center / (std + self.epsilon)
         if self.learnable:
             output = self.alpha * output + self.beta

--- a/lstms/normalize.py
+++ b/lstms/normalize.py
@@ -1,18 +1,14 @@
 #!/usr/bin/env python
-
-import math
-import torch as th
-import torch.nn as nn
-import torch.nn.functional as F
-from torch import Tensor as T
-from torch.nn import Parameter as P
-from torch.autograd import Variable as V
-
 """
 Implementation of various normalization techniques. Also only works on instances
 where batch size = 1.
-
 """
+import math
+
+import torch as th
+import torch.nn as nn
+from torch.autograd import Variable
+from torch.nn import Parameter
 
 
 class LayerNorm(nn.Module):
@@ -26,14 +22,14 @@ class LayerNorm(nn.Module):
         super(LayerNorm, self).__init__()
         self.input_size = input_size
         self.learnable = learnable
-        self.alpha = T(1, input_size).fill_(0)
-        self.beta = T(1, input_size).fill_(0)
+        self.alpha = th.empty(1, input_size).fill_(0)
+        self.beta = th.empty(1, input_size).fill_(0)
         self.epsilon = epsilon
         # Wrap as parameters if necessary
         if learnable:
-            W = P
+            W = Parameter
         else:
-            W = V
+            W = Variable
         self.alpha = W(self.alpha)
         self.beta = W(self.beta)
         self.reset_parameters()
@@ -81,18 +77,19 @@ class BaLayerNorm(nn.Module):
     This implementation mimicks the original torch implementation at:
     https://github.com/ryankiros/layer-norm/blob/master/torch_modules/LayerNormalization.lua
     """
+
     def __init__(self, input_size, learnable=True, epsilon=1e-5):
         super(BaLayerNorm, self).__init__()
         self.input_size = input_size
         self.learnable = learnable
         self.epsilon = epsilon
-        self.alpha = T(1, input_size).fill_(0)
-        self.beta = T(1, input_size).fill_(0)
+        self.alpha = th.empty(1, input_size).fill_(0)
+        self.beta = th.empty(1, input_size).fill_(0)
         # Wrap as parameters if necessary
         if learnable:
-            W = P
+            W = Parameter
         else:
-            W = V
+            W = Variable
         self.alpha = W(self.alpha)
         self.beta = W(self.beta)
 


### PR DESCRIPTION
The commit messages are pretty self explanatory, but here is a quick list of changes in this pull request:
1. `from lstm import ...` will now only allow to import local classes,
2. Used more readable class names instead of `T` and `P` and more readable variable names,
3. Deleted unused imports and formatted source code files using black formatter,
4. Fixed some runtime bug in layer normalization classes,
5. Fixed subclasses of LayerNormLSTM class,
6. Got rid of `Variable`s because it was [deprecated](https://pytorch.org/docs/stable/autograd.html#variable-deprecated),
7. Added type hinting and made some quality improvements such as accepting 0 length `layer_sizes` in `MultiLayerLSTM` (in which case it acts as the identity function).